### PR TITLE
Upgrade to iOS RNBranch 0.28.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+2019-10-02  Version 3.2.0
+  - Requires RN < 0.60
+  - Uses native Branch SDKs 3.2.0 (Android), 0.28.1 (iOS).
+
 2019-07-25  Version 3.1.1
   - Requires RN < 0.60
   - Fix a runtime iOS issue in 3.1.0

--- a/docs/carthage.md
+++ b/docs/carthage.md
@@ -12,7 +12,7 @@ react-native link react-native-branch
 If you already have a Cartfile, add this to your Cartfile:
 
 ```
-github "BranchMetrics/ios-branch-deep-linking" "0.27.0"
+github "BranchMetrics/ios-branch-deep-linking" "0.28.1"
 ```
 
 Now run `carthage build`.

--- a/docs/cocoapods.md
+++ b/docs/cocoapods.md
@@ -18,7 +18,7 @@ The third option is to use [Carthage](./carthage.md).
 
 ## Prerequisites
 
-Install CocoaPods if necessary.  
+Install CocoaPods if necessary.
 https://guides.cocoapods.org/using/getting-started.html#installation
 
 ## Installation using the React pod
@@ -70,7 +70,7 @@ method if you have a tvOS app, since the React pod will not build for tvOS.
 If you are already using CocoaPods, add this to your Podfile:
 
 ```Ruby
-pod 'Branch', '0.27.0'
+pod 'Branch', '0.28.1'
 ```
 
 **Note:** The required version of the Branch SDK may differ. In that case,
@@ -99,7 +99,7 @@ target 'MyApp' do
   # use_frameworks!
 
   # iOS dependencies
-  pod 'Branch', '0.27.0'
+  pod 'Branch', '0.28.1'
 
   target 'MyAppTests' do
     # Add any additional dependencies for the test target

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,7 +56,7 @@ end
 
 # Examples:
 # bundle exec fastlane native_update android_version:"3.2.0", # Android SDK version from Maven
-# bundle exec fastlane native_update ios_version:"0.27.1", # iOS SDK version from CocoaPods
+# bundle exec fastlane native_update ios_version:"0.28.1", # iOS SDK version from CocoaPods
 # bundle exec fastlane native_update repo_update:no # Don't update CocoaPods repo
 # bundle exec fastlane native_update include_examples:yes # Also update all example lockfiles
 # bundle exec fastlane native_update commit:no, # Don't commit the results. Default: true

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -29,7 +29,7 @@ static NSString * const IdentFieldName = @"ident";
 static NSString * const RNBranchErrorDomain = @"RNBranchErrorDomain";
 static NSInteger const RNBranchUniversalObjectNotFoundError = 1;
 
-static NSString * const REQUIRED_BRANCH_SDK = @"0.27.1";
+static NSString * const REQUIRED_BRANCH_SDK = @"0.28.1";
 
 #pragma mark - Private RNBranch declarations
 
@@ -90,7 +90,7 @@ RCT_EXPORT_MODULE();
         [instance delayInitToCheckForSearchAds];
     }
     if (config.appleSearchAdsDebugMode) {
-        [instance setAppleSearchAdsDebugMode];
+        [RNBranch setAppleSearchAdsDebugMode];
     }
 }
 
@@ -149,7 +149,7 @@ RCT_EXPORT_MODULE();
 
 + (void)setAppleSearchAdsDebugMode
 {
-    [self.branch setAppleSearchAdsDebugMode];
+    [RNBranch setAppleSearchAdsDebugMode];
 }
 
 + (void)setRequestMetadataKey:(NSString *)key value:(NSObject *)value

--- a/native-tests/ios/Podfile.lock
+++ b/native-tests/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - Branch (0.27.1):
-    - Branch/Core (= 0.27.1)
-  - Branch/Core (0.27.1)
+  - Branch (0.28.1):
+    - Branch/Core (= 0.28.1)
+  - Branch/Core (0.28.1)
   - DoubleConversion (1.1.5)
   - Folly (2018.10.22.00):
     - boost-for-react-native
@@ -18,7 +18,7 @@ PODS:
   - React (0.59.10):
     - React/Core (= 0.59.10)
   - react-native-branch (3.1.2):
-    - Branch (= 0.27.1)
+    - Branch (= 0.28.1)
     - React
   - React/Core (0.59.10):
     - yoga (= 0.59.10.React)

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "7.0"
   s.source       = { spec['repository']['type'].to_sym => spec['repository']['url'].sub(/^[a-z]+\+/, '') }
   s.source_files = [ "ios/*.h", "ios/*.m"]
-  s.dependency 'Branch', '0.27.1'
+  s.dependency 'Branch', '0.28.1'
   s.dependency 'React' # to ensure the correct build order
 end


### PR DESCRIPTION
Follows the steps here to upgrade RNBranch to 0.28.1. 

https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/pull/497/files